### PR TITLE
Update of the instructions to install the SSCHA with Flare and AiiDaQE

### DIFF
--- a/workstation/linux/flare+aiida+sscha/README.md
+++ b/workstation/linux/flare+aiida+sscha/README.md
@@ -13,7 +13,9 @@ These instructions should work out of the box. If you encounter any issue, you c
 Create the conda environment:
 
 ```console
-mamba create -yn sscha-flare -c conda-forge python=3.9 numpy git spglib=2.2 scipy pytest julia gfortran libblas lapack pip gcc gxx cmake openmp liblapacke openblas aiida-core aiida-core.services
+mamba create -yn sscha-flare -c conda-forge python=3.9 numpy git \
+spglib=2.2 scipy pytest julia gfortran libblas lapack pip gcc gxx \
+cmake openmp liblapacke openblas aiida-core aiida-core.services
 mamba activate sscha-flare
 ```
 
@@ -67,18 +69,18 @@ Usually, the known issues are:
     Look also this [discussion](https://community.intel.com/t5/Intel-oneAPI-Math-Kernel-Library/mkl-fails-to-load/m-p/1155538). 
     If you compiled with a "custom" intel-MKL, then you should substitue `${CONDA_PREFIX}/lib` with the appropiate path(s) (see the discussion for hints on paths).
   
-- Installing a package using `python setup install` is usually deprecated, and one should rather use pip. Nevertheless, we recommend using it here because the installation of `CellConstructor` and `python-sscha` can conflict with Julia installation when using pip. If you prefer to install SSCHA using pip anyway, you may encounter an error when building the `PyCall` and `Conda` Julia dependencies. Usually, installing the other packages manually first and then the remaining two with the standard procedure will solve the problem. Proceed as follows:
+- Installing a package using `python setup install` is usually deprecated, and one should rather use pip. Nevertheless, we recommend using it here because the installation of CellConstructor and python-sscha can conflict with Julia installation when using pip. If you prefer to install SSCHA using pip anyway, you may encounter an error when building the PyCall and Conda julia dependencies. Usually, installing the other packages manually first and then the remaining two with the standard procedure will solve the problem. Proceed as follows:
     Type `julia`. Inside the julia prompt, type `]`. The prompt should change color and display the julia version ending with `pkg>`.
     Install the packages:
     ```console
     pkg> add SparseArrays, LinearAlgebra, InteractiveUtils, PyCall
     ```
-    This will build all the other dependencies and will raise an error for `Conda` and `PyCall` that you should ignore.
+    This will build all the other dependencies and will raise an error for Conda and PyCall that you should ignore.
     Press backspace to return to the standard julia prompt and exit with
     ```console
     julia> exit()
     ```
-    Finally, having the other dependencies installed, julia will handle the error of `PyCall` and `Conda`. You can install them using:
+    Finally, having the other dependencies installed, julia will handle the error of PyCall and Conda. You can install them using:
     ```console
     python -c 'import julia; julia.install()'
     ```

--- a/workstation/linux/flare+aiida+sscha/README.md
+++ b/workstation/linux/flare+aiida+sscha/README.md
@@ -13,16 +13,14 @@ These instructions should work out of the box. If you encounter any issue, you c
 Create the conda environment:
 
 ```console
-mamba create -yn sscha-flare -c conda-forge \
-    python=3.9 gfortran libblas lapack julia \
-    pip numpy scipy spglib=2.2 gcc gxx cmake openmp liblapacke openblas \
-    aiida-core aiida-core.services
+mamba create -yn sscha-flare -c conda-forge python=3.9 numpy git spglib=2.2 scipy pytest julia gfortran libblas lapack pip gcc gxx cmake openmp liblapacke openblas aiida-core aiida-core.services
 mamba activate sscha-flare
 ```
 
+
 Clone the following packages under development:
 ```console
-git clone -b development https://github.com/mir-group/flare.git
+git clone -b development --depth 1 https://github.com/mir-group/flare.git
 git clone -b new/flare-interface --depth 1 https://github.com/bastonero/python-sscha.git
 git clone --depth 1 https://github.com/SSCHAcode/CellConstructor.git
 ```
@@ -30,42 +28,28 @@ git clone --depth 1 https://github.com/SSCHAcode/CellConstructor.git
 One should also consider properly install AiiDA and making an AiiDA profile afterwards, and set computer and codes.
 
 Install aiida-quantumespresso and some other packages via pip:
-
 ```console
-pip install ase julia aiida-quantumespresso aiida-pseudo
+pip install ase==3.22 julia aiida-quantumespresso aiida-pseudo
+```
+
+Install flare:
+```console
+cd flare
+pip install .
 ```
 
 Install the SSCHA and its dependencies:
-
-```
-cd CellConstructor
+```console
+cd ../CellConstructor
 python setup.py install
 cd ../python-sscha
 python setup.py install
 pip install tdscha
 ```
 
-Now, type `julia`. Inside the julia prompt, type `]`. The prompt should change color and display the julia version ending with `pkg>`. Proceed as follows:
-
-```console
-pkg> add SparseArrays, LinearAlgebra, InteractiveUtils, PyCall
-```
-
-This should install the required libraries. Press backspace to return to the standard julia prompt and exit with
-
-```console
-julia> exit()
-```
-
-Setup the julia dependencies correctly:
+Finally, the SSCHA benefits from julia to automatically speedup the calculation. Install the julia dependencies:
 ```console
 python -c 'import julia; julia.install()'
-```
-
-Finally install flare:
-```
-cd ../flare
-python setup.py install
 ```
 
 ## Known issues
@@ -81,6 +65,20 @@ Usually, the known issues are:
     If this doens't solve the issue, then don't use MKL. If you need MKL, e.g. for QE or NequIP, then a possible solution is to first install the other dependencies for FLARE, install FLARE, and then install MKL in the conda/mamba environment along with the other needed packages.
 
     Look also this [discussion](https://community.intel.com/t5/Intel-oneAPI-Math-Kernel-Library/mkl-fails-to-load/m-p/1155538). 
-    If you compiled with a "custom" intel-MKL, then you should substitue `${CONDA_PREFIX}/lib` with the appropiate path(s) (see the discussion for hints on paths). 
-
-- NequIP CPU only would probably crash if you also install torch-vision and torch-audio. Just don't install them, they are not needed anyways.
+    If you compiled with a "custom" intel-MKL, then you should substitue `${CONDA_PREFIX}/lib` with the appropiate path(s) (see the discussion for hints on paths).
+  
+- Installing a package using `python setup install` is usually deprecated, and one should rather use pip. Nevertheless, we recommend using it here because the installation of `CellConstructor` and `python-sscha` can conflict with Julia installation when using pip. If you prefer to install SSCHA using pip anyway, you may encounter an error when building the `PyCall` and `Conda` Julia dependencies. Usually, installing the other packages manually first and then the remaining two with the standard procedure will solve the problem. Proceed as follows:
+    Type `julia`. Inside the julia prompt, type `]`. The prompt should change color and display the julia version ending with `pkg>`.
+    Install the packages:
+    ```console
+    pkg> add SparseArrays, LinearAlgebra, InteractiveUtils, PyCall
+    ```
+    This will build all the other dependencies and will raise an error for `Conda` and `PyCall` that you should ignore.
+    Press backspace to return to the standard julia prompt and exit with
+    ```console
+    julia> exit()
+    ```
+    Finally, having the other dependencies installed, julia will handle the error of `PyCall` and `Conda`. You can install them using:
+    ```console
+    python -c 'import julia; julia.install()'
+    ```


### PR DESCRIPTION
Change the procedure:
- Flare should be installed using pip and must be installed before the SSCHA packages.
- Adding manually the Julia dependencies is only necessary when installing the SSCHA ones using pip.

Updated the package list: 
- git is needed
- the version of ase as to be set to 3.22

Updated the known error section and description of the procedure.